### PR TITLE
Avoid invalid memory accesses.

### DIFF
--- a/src/lib/PointsTableProjector.cc
+++ b/src/lib/PointsTableProjector.cc
@@ -26,6 +26,9 @@ while(false)
 PointsTableProjector::PointsTableProjector(std::string const& fname)
 : fname(fname)
 {
+    // Prevent reallocation in this member, because we are going to store
+    // references to its elements in another member.
+    this->teams.reserve(1024);
     this->parse();
 }
 


### PR DESCRIPTION
Since `this->fixtures` stores references to elements in `this->teams`, if the latter undergoes reallocation when new elements are added to it, the former will contain dangling references. This is avoided by reserving a large amount of space in the beginning.