### PR TITLE
Addressed a pet peeve I have about the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 CPPFLAGS = -Isrc/include
 CXXFLAGS = -std=c++17 -O2 -Wall -Wextra -flto -fstrict-aliasing
+LDFLAGS = -flto
 
 Sources = $(wildcard src/lib/*.cc)
 Objects = $(Sources:.cc=.o)
 
 project: $(Objects)
-	$(LINK.cc) -o $@ $^
+	$(CXX) $(LDFLAGS) -o $@ $^


### PR DESCRIPTION
The link command should not include all the extra flags. It does no harm, and does not change the resulting binary at all (I compared SHA-256 sums), but I don't like it.